### PR TITLE
Default to empty string when cleaning strings

### DIFF
--- a/packages/joi/src/types/string.js
+++ b/packages/joi/src/types/string.js
@@ -8,7 +8,7 @@ export default (joi) => ({
     let v = value;
     if (!helpers.schema.$_getRule('html')) {
       // no html rule set. strip all tags
-      v = cleanHtml(v, { allowedTags: [] });
+      v = cleanHtml(v, { allowedTags: [], defaultValue: '' });
     }
 
     if (!helpers.schema.$_getFlag('multiline')) {


### PR DESCRIPTION
When supplied a value such as `<span class=` for a multiline HTML string, change the default return value to an empty string, instead of the underlying default value (null).

Currently, this value will error on L16, as `.replace` won't be present, and the Joi validation will hard error.